### PR TITLE
Fix Test-InstalledWAU to search both registry paths

### DIFF
--- a/Sources/WAU Settings GUI/WAU-Settings-GUI.ps1
+++ b/Sources/WAU Settings GUI/WAU-Settings-GUI.ps1
@@ -1167,9 +1167,12 @@ function Test-InstalledWAU {
 
     # Try up to 3 times to find WAU installation (handles timing issues with self-updates)
     for ($attempt = 1; $attempt -le 3; $attempt++) {
-        $uninstallKeys = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall"
+        $uninstallKeys = @(
+            "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",
+            "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall"
+        )
         $matchingApps = @()
-        
+
         foreach ($key in $uninstallKeys) {
             try {
                 $subKeys = Get-ChildItem -Path $key -ErrorAction Stop


### PR DESCRIPTION
## Summary
- Fixed `Test-InstalledWAU` function to search both 64-bit and 32-bit registry uninstall paths
- Resolves issue where WAU installation prompt appeared even when WAU was installed

## Problem
The function was only checking the 64-bit registry path (`HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall`), causing it to fail detecting installed applications in certain scenarios, particularly when running from PowerShell ISE.

## Solution
Changed `$uninstallKeys` from a single string to an array containing both:
- `HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall` (64-bit applications)
- `HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall` (32-bit applications on 64-bit Windows)

## Test Plan
- [x] Verified function now correctly detects WAU installation
- [x] Tested from PowerShell ISE as Administrator
- [x] Confirmed function returns expected values (version and GUID)

🤖 Generated with [Claude Code](https://claude.com/claude-code)