### PR TITLE
Revert "Fix Test-InstalledWAU to search both 64-bit and 32-bit regist…

### DIFF
--- a/Sources/WAU Settings GUI/WAU-Settings-GUI.ps1
+++ b/Sources/WAU Settings GUI/WAU-Settings-GUI.ps1
@@ -1167,12 +1167,9 @@ function Test-InstalledWAU {
 
     # Try up to 3 times to find WAU installation (handles timing issues with self-updates)
     for ($attempt = 1; $attempt -le 3; $attempt++) {
-        $uninstallKeys = @(
-            "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",
-            "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall"
-        )
+        $uninstallKeys = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall"
         $matchingApps = @()
-
+        
         foreach ($key in $uninstallKeys) {
             try {
                 $subKeys = Get-ChildItem -Path $key -ErrorAction Stop


### PR DESCRIPTION
…ry paths"

This reverts commit 4b93da7. The issue was not related to registry path detection. The actual problem is in the initialization flow when running from PowerShell ISE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)