### PR TITLE
Update CLAUDE.md: Clarify PS1 execution guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,18 +142,20 @@ Close-PopUp
 
 ### Running for Development
 
+**IMPORTANT**: WAU-Settings-GUI.ps1 should NOT be run directly from PowerShell (except for `-SandboxTest`). The application must be launched via:
+- The compiled `.exe` file
+- Desktop/Start Menu shortcuts created during installation
+
+**For development/testing only**:
+
 From `Sources/WAU Settings GUI/`:
 
 ```powershell
-.\WAU-Settings-GUI.ps1              # Normal mode
-.\WAU-Settings-GUI.ps1 -Verbose     # Debug mode
-.\WAU-Settings-GUI.ps1 -Portable    # No shortcuts/registry artifacts
-.\WAU-Settings-GUI.ps1 -SandboxTest # Windows Sandbox test mode
+.\WAU-Settings-GUI.ps1 -SandboxTest # Windows Sandbox test mode (standalone)
 ```
 
 **Parameters**:
-- `-Portable` - Runs in portable mode without creating shortcuts or registry entries
-- `-SandboxTest` - Launches the Windows Sandbox testing interface directly
+- `-SandboxTest` - Launches the Windows Sandbox testing interface directly (does not require the main GUI)
 
 ### Building the EXE
 


### PR DESCRIPTION
## Summary
- Clarified that WAU-Settings-GUI.ps1 should NOT be run directly from PowerShell
- Only `-SandboxTest` parameter is intended for direct execution during development

## Problem
Running WAU-Settings-GUI.ps1 directly from PowerShell causes initialization issues and shortcut creation errors. The script is designed to be run through:
- The compiled `.exe` file
- Desktop/Start Menu shortcuts created during installation

## Changes
- Added prominent **IMPORTANT** note about not running .ps1 directly
- Removed documentation for `-Verbose` and `-Portable` direct execution
- Clarified that only `-SandboxTest` is for standalone development use
- Updated parameter descriptions to reflect correct usage

## Documentation Impact
This makes it clear to developers and users that the .ps1 file is not a standalone script but part of the compiled application workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)