### PR TITLE
Fix: spurious Unsaved Changes dialog when deadline is disabled

### DIFF
--- a/Sources/WAU Settings GUI/WAU-Settings-GUI.ps1
+++ b/Sources/WAU Settings GUI/WAU-Settings-GUI.ps1
@@ -4044,15 +4044,18 @@ function Test-SettingsChanged {
             $guiDeadlineDays = $controls.UpdateDeadlineDaysComboBox.SelectedItem.Content
             if ($savedDeadlineDays -ne $guiDeadlineDays) { $changes += "Update Deadline Days" }
 
-            $savedReminderDays = Get-DisplayValue "WAU_ReminderIntervalDays" $currentConfig $policies
-            $guiReminderDays = if ($controls.ReminderIntervalDaysComboBox.SelectedItem) {
-                [int]$controls.ReminderIntervalDaysComboBox.SelectedItem.Content
-            } else { 2 }
-            if ($savedReminderDays -ne $guiReminderDays) { $changes += "Reminder Interval Days" }
+            # Only compare deadline-dependent values when the feature is active (mirrors Save-WAUSettings logic)
+            if ([int]$guiDeadlineDays -gt 0) {
+                $savedReminderDays = Get-DisplayValue "WAU_ReminderIntervalDays" $currentConfig $policies
+                $guiReminderDays = if ($controls.ReminderIntervalDaysComboBox.SelectedItem) {
+                    [int]$controls.ReminderIntervalDaysComboBox.SelectedItem.Content
+                } else { 2 }
+                if ($savedReminderDays -ne $guiReminderDays) { $changes += "Reminder Interval Days" }
 
-            $savedCompanyName = Get-DisplayValue "WAU_CompanyName" $currentConfig $policies
-            $guiCompanyName = $controls.CompanyNameTextBox.Text
-            if ($savedCompanyName -ne $guiCompanyName) { $changes += "Company Name" }
+                $savedCompanyName = Get-DisplayValue "WAU_CompanyName" $currentConfig $policies
+                $guiCompanyName = $controls.CompanyNameTextBox.Text
+                if ($savedCompanyName -ne $guiCompanyName) { $changes += "Company Name" }
+            }
         }
 
         return @{


### PR DESCRIPTION
## Summary

Followup fix for PR #102.

`Test-SettingsChanged` always compared `WAU_ReminderIntervalDays` and `WAU_CompanyName` against the registry. After #102, these values are only written when `WAU_UpdateDeadlineDays > 0`. With no registry values present (null), the comparison saw a mismatch and showed the "Unsaved Changes" dialog on every close — even when the user hadn't changed anything.

Fix mirrors the same `if ($deadlineDays -gt 0)` conditional that `Save-WAUSettings` uses, so the two functions stay in sync.

## Test plan
- [ ] Open GUI with deadline=0, close without saving → **no dialog**
- [ ] Change deadline to 5, change reminder to 3, close without saving → **dialog appears**
- [ ] Save with deadline=5, close immediately → **no dialog**
- [ ] Change deadline back to 0, close without saving → **dialog appears** (deadline itself changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)