### PR TITLE
Fix: treat missing deadline registry values as WAU defaults in change detection

### DIFF
--- a/Sources/WAU Settings GUI/WAU-Settings-GUI.ps1
+++ b/Sources/WAU Settings GUI/WAU-Settings-GUI.ps1
@@ -4040,19 +4040,23 @@ function Test-SettingsChanged {
             if ($savedMaxLogSize -ne $guiMaxLogSize) { $changes += "Max Log Size" }
 
             # Update Deadline settings
+            # Treat missing registry values as WAU defaults to avoid false change detection on new installations
             $savedDeadlineDays = Get-DisplayValue "WAU_UpdateDeadlineDays" $currentConfig $policies
+            if ($null -eq $savedDeadlineDays) { $savedDeadlineDays = "0" }
             $guiDeadlineDays = $controls.UpdateDeadlineDaysComboBox.SelectedItem.Content
             if ($savedDeadlineDays -ne $guiDeadlineDays) { $changes += "Update Deadline Days" }
 
             # Only compare deadline-dependent values when the feature is active (mirrors Save-WAUSettings logic)
             if ([int]$guiDeadlineDays -gt 0) {
                 $savedReminderDays = Get-DisplayValue "WAU_ReminderIntervalDays" $currentConfig $policies
+                if ($null -eq $savedReminderDays) { $savedReminderDays = 2 }
                 $guiReminderDays = if ($controls.ReminderIntervalDaysComboBox.SelectedItem) {
                     [int]$controls.ReminderIntervalDaysComboBox.SelectedItem.Content
                 } else { 2 }
                 if ($savedReminderDays -ne $guiReminderDays) { $changes += "Reminder Interval Days" }
 
                 $savedCompanyName = Get-DisplayValue "WAU_CompanyName" $currentConfig $policies
+                if ($null -eq $savedCompanyName) { $savedCompanyName = "" }
                 $guiCompanyName = $controls.CompanyNameTextBox.Text
                 if ($savedCompanyName -ne $guiCompanyName) { $changes += "Company Name" }
             }


### PR DESCRIPTION
## Summary

Third followup fix for PR #101 (deadline prompt system).

On fresh WAU installations the three new registry keys (`WAU_UpdateDeadlineDays`, `WAU_ReminderIntervalDays`, `WAU_CompanyName`) do not yet exist. `Get-DisplayValue` returns `$null` for them. In PowerShell 5.1, `$null -ne "0"` and `$null -ne 2` are both `$true`, so `Test-SettingsChanged` flagged these as changes and showed the "Unsaved Changes" dialog on every close, even without user interaction.

Fix: normalize `$null` to each key's WAU default (`"0"`, `2`, `""`) before comparing, so only real user changes are detected.

Fixes after PR #102 and PR #103.

## Test plan
- [ ] Open GUI on installation where deadline keys have never been saved → close → **no dialog**
- [ ] Change deadline to 5 → close without saving → **dialog appears**
- [ ] Save with deadline=5 → close → **no dialog**

🤖 Generated with [Claude Code](https://claude.com/claude-code)